### PR TITLE
Add http proxy support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,6 @@ repositories {
     maven(url = "https://papermc.io/repo/repository/maven-public/")
     maven(url = "https://oss.sonatype.org/content/groups/public/")
     maven(url = "https://jitpack.io")
-
 }
 
 dependencies {

--- a/src/main/kotlin/nya/yukisawa/paper_tg_bridge/AsyncJavaPlugin.kt
+++ b/src/main/kotlin/nya/yukisawa/paper_tg_bridge/AsyncJavaPlugin.kt
@@ -1,6 +1,11 @@
 package nya.yukisawa.paper_tg_bridge
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.bukkit.plugin.java.JavaPlugin
 
 open class AsyncJavaPlugin : JavaPlugin() {

--- a/src/main/kotlin/nya/yukisawa/paper_tg_bridge/Configuration.kt
+++ b/src/main/kotlin/nya/yukisawa/paper_tg_bridge/Configuration.kt
@@ -41,6 +41,10 @@ class Configuration(plugin: Plugin) {
 
     val debug: Boolean
 
+    val proxyEnabled: Boolean
+    val proxyHost: String
+    val proxyPort: Int
+
     init {
         val cfgFile = File(plugin.dataFolder, C.configFilename)
         if (!cfgFile.exists()) {
@@ -91,6 +95,10 @@ class Configuration(plugin: Plugin) {
             commands = BotCommands(this)
 
             debug = getBoolean("debug", false)
+
+            proxyEnabled = getBoolean("proxy.enabled", false)
+            proxyHost = getString("proxy.host", "")!!
+            proxyPort = getInt("proxy.port", 10809)
         }
     }
 

--- a/src/main/kotlin/nya/yukisawa/paper_tg_bridge/Entities.kt
+++ b/src/main/kotlin/nya/yukisawa/paper_tg_bridge/Entities.kt
@@ -8,7 +8,6 @@ data class TgResponse<T>(
     val description: String?,
 )
 
-
 data class Update(
     @Name("update_id") val updateId: Long,
     val message: Message? = null,
@@ -73,8 +72,6 @@ data class Media(
     val duration: Int
 )
 
-
 data class BotCommand(val command: String, val description: String)
 
 data class SetMyCommands(val commands: List<BotCommand>)
-

--- a/src/main/kotlin/nya/yukisawa/paper_tg_bridge/EventHandler.kt
+++ b/src/main/kotlin/nya/yukisawa/paper_tg_bridge/EventHandler.kt
@@ -55,7 +55,6 @@ class EventHandler(
         }
     }
 
-
     @EventHandler
     fun onPlayerAsleep(event: PlayerBedEnterEvent) {
         if (!config.logPlayerAsleep) return
@@ -87,7 +86,6 @@ class EventHandler(
                 sendMessage(text)
             } else sendMessage(titleKey)
         }
-
     }
 
     private fun sendMessage(text: String, username: String? = null) {

--- a/src/main/kotlin/nya/yukisawa/paper_tg_bridge/Plugin.kt
+++ b/src/main/kotlin/nya/yukisawa/paper_tg_bridge/Plugin.kt
@@ -26,8 +26,6 @@ class Plugin : AsyncJavaPlugin() {
 
     private suspend fun initializeWithConfig(config: Configuration) {
         if (!config.isEnabled) return
-
-
         tgBot?.run { stop() }
         tgBot = TgBot(this, config).also { bot ->
             bot.startPolling()
@@ -64,15 +62,15 @@ class Plugin : AsyncJavaPlugin() {
     ) = config?.run {
         val format = Component.text(
             minecraftFormat
-            .replace(C.USERNAME_PLACEHOLDER,username)
-            .replace(C.CHAT_TITLE_PLACEHOLDER, chatTitle)
+                .replace(C.USERNAME_PLACEHOLDER, username)
+                .replace(C.CHAT_TITLE_PLACEHOLDER, chatTitle)
         ).replaceText(
             TextReplacementConfig.builder()
                 .match(C.MESSAGE_TEXT_PLACEHOLDER)
                 .replacement(text)
                 .once()
                 .build()
-            )
+        )
         server.broadcast(format)
 
     }

--- a/src/main/kotlin/nya/yukisawa/paper_tg_bridge/TgBot.kt
+++ b/src/main/kotlin/nya/yukisawa/paper_tg_bridge/TgBot.kt
@@ -14,7 +14,6 @@ import retrofit2.converter.gson.GsonConverterFactory
 import java.lang.Runnable
 import java.net.InetSocketAddress
 import java.net.Proxy
-import java.net.SocketAddress
 import java.time.Duration
 import java.util.*
 import nya.yukisawa.paper_tg_bridge.Constants as C
@@ -51,7 +50,10 @@ class TgBot(
         }, 100)
     }
 
-    private val proxy: Proxy = if (!config.proxyEnabled) Proxy.NO_PROXY else Proxy(Proxy.Type.HTTP, InetSocketAddress(config.proxyHost, config.proxyPort))
+    private val proxy: Proxy = if (!config.proxyEnabled) Proxy.NO_PROXY else Proxy(
+        Proxy.Type.HTTP,
+        InetSocketAddress(config.proxyHost, config.proxyPort)
+    )
     private val client: OkHttpClient = OkHttpClient
         .Builder()
         .proxy(proxy)
@@ -107,7 +109,7 @@ class TgBot(
     }
 
     private fun initPolling() = plugin.launch {
-        loop@while (true) {
+        loop@ while (true) {
             try {
                 api.getUpdates(
                     offset = currentOffset,
@@ -142,7 +144,7 @@ class TgBot(
     }
 
     private suspend fun handleUpdate(update: Update) {
-        if(config.debug) plugin.server.logger.info(update.toString())
+        if (config.debug) plugin.server.logger.info(update.toString())
         // Ignore private message or channel post
         if (update.message?.chat?.type != "group" && update.message?.chat?.type != "supergroup")
             return
@@ -204,7 +206,11 @@ class TgBot(
         val playerList = plugin.server.onlinePlayers
         val playerStr = plugin.server
             .onlinePlayers
-            .mapIndexed { i, s -> "${i + 1}. ${PlainTextComponentSerializer.plainText().serialize(s.displayName()).fullEscape()}" }
+            .mapIndexed { i, s ->
+                "${i + 1}. ${
+                    PlainTextComponentSerializer.plainText().serialize(s.displayName()).fullEscape()
+                }"
+            }
             .joinToString("\n")
         val text =
             if (playerList.isNotEmpty()) "${config.onlineString}:\n$playerStr"

--- a/src/main/kotlin/nya/yukisawa/paper_tg_bridge/TgBot.kt
+++ b/src/main/kotlin/nya/yukisawa/paper_tg_bridge/TgBot.kt
@@ -12,6 +12,9 @@ import org.bukkit.Bukkit
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.lang.Runnable
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.SocketAddress
 import java.time.Duration
 import java.util.*
 import nya.yukisawa.paper_tg_bridge.Constants as C
@@ -47,8 +50,11 @@ class TgBot(
             }
         }, 100)
     }
+
+    private val proxy: Proxy = if (!config.proxyEnabled) Proxy.NO_PROXY else Proxy(Proxy.Type.HTTP, InetSocketAddress(config.proxyHost, config.proxyPort))
     private val client: OkHttpClient = OkHttpClient
         .Builder()
+        .proxy(proxy)
         .readTimeout(Duration.ZERO)
         .build()
     private val api = Retrofit.Builder()

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -32,6 +32,6 @@ commands:
 telegramAPI: "api.telegram.org"
 debug: true
 proxy:
-  enable: false
+  enabled: false
   host: "localhost"
   port: 10809

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,3 +31,7 @@ commands:
   command: "command"
 telegramAPI: "api.telegram.org"
 debug: true
+proxy:
+  enable: false
+  host: "localhost"
+  port: 10809


### PR DESCRIPTION
当我们的MC服务端运行于网络状况不好的机器上，我们可能会需要一个代理服务器。  
之所以不用全局代理是因为 Java 默认不走全局代理。  
所以添加了使用 HTTP 代理的功能，在配置文件中增加了三个选项如下：  
```yaml
proxy:
  enabled: true
  host: "localhost"
  port: 10809
```